### PR TITLE
Multithread enabled in exec with multi-stores

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -4,7 +4,7 @@ wit_bindgen_rust::export!("../event-handler.wit");
 fn main() {
     println!("executing in the guest...");
     let events = exec::Events::get();
-    for _ in 0..10 {
+    for _ in 0..2 {
         events.exec();
     }
     println!("finishing in the guest...")

--- a/src/host.rs
+++ b/src/host.rs
@@ -21,7 +21,7 @@ pub mod exec {
         linker.func_wrap(
             "exec",
             "events::get",
-            move |mut caller: wasmtime::Caller<'_, Context>| {
+            move |caller: wasmtime::Caller<'_, Context>| {
                 let store = caller.as_context();
                 let _tables = store.data().host.1.as_ref().unwrap();
                 let handle = _tables.clone().lock().unwrap().events_table.insert(());
@@ -31,7 +31,7 @@ pub mod exec {
         linker.func_wrap(
             "exec",
             "events::exec",
-            move |mut caller: wasmtime::Caller<'_, Context>, arg0: i32| {
+            move |mut caller: wasmtime::Caller<'_, Context>, _arg0: i32| {
                 let store = caller.as_context();
                 let handler = store.data().host.0.as_ref().unwrap().clone();
                 let mut store = caller.as_context_mut();
@@ -49,10 +49,10 @@ pub mod exec {
         linker.func_wrap(
             "canonical_abi",
             "resource_drop_events",
-            move |mut caller: wasmtime::Caller<'_, Context>, handle: u32| {
+            move |caller: wasmtime::Caller<'_, Context>, handle: u32| {
                 let store = caller.as_context();
                 let _tables = store.data().host.1.as_ref().unwrap();
-                let handle = _tables
+                _tables
                     .clone()
                     .lock()
                     .unwrap()

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
         move |mut _caller: CallerCtx2, _arg0: i32| Ok(()),
     )?;
     linker2.func_wrap("exec", "events::get", move |mut _caller: CallerCtx2| {
-        Ok(0 as i32)
+        Ok(0_i32)
     })?;
     linker2.func_wrap(
         "canonical_abi",

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ use event_handler::{EventHandler, EventHandlerData};
 use host::exec::{self, ExecTables};
 use wasi_cap_std_sync::WasiCtxBuilder;
 use wasi_common::{StringArrayError, WasiCtx};
-use wasmtime::{Config, Engine, Linker, Module, Store};
+use wasmtime::{
+    Config, Engine, Global, GlobalType, Linker, Module, Mutability, Store, Val, ValType,
+};
 use wasmtime_wasi::*;
 
 mod host;
@@ -14,36 +16,56 @@ wit_bindgen_wasmtime::import!("event-handler.wit");
 
 pub struct Context {
     pub wasi: WasiCtx,
-    pub guest: EventHandlerData,
     pub host: (
-        Option<Arc<Mutex<EventHandler<Self>>>>,
+        Option<Arc<Mutex<EventHandler<Context2>>>>,
         Option<Arc<Mutex<ExecTables>>>,
+        Option<Arc<Mutex<Store<Context2>>>>,
     ),
 }
 
+pub struct Context2 {
+    pub wasi: WasiCtx,
+    pub guest: EventHandlerData,
+}
+
 fn main() -> Result<()> {
-    let wasi = default_wasi()?;
     let guest = EventHandlerData::default();
     let ctx = Context {
-        wasi,
+        wasi: default_wasi()?,
+        host: (None, None, None),
+    };
+
+    let ctx2 = Context2 {
+        wasi: default_wasi()?,
         guest,
-        host: (None, None),
     };
 
     let engine = Engine::new(&default_config()?)?;
     let mut linker = Linker::new(&engine);
+    let mut linker2 = Linker::new(&engine);
     let mut store = Store::new(&engine, ctx);
+    let mut store2 = Store::new(&engine, ctx2);
     wasmtime_wasi::add_to_linker(&mut linker, |cx: &mut Context| &mut cx.wasi)?;
+    wasmtime_wasi::add_to_linker(&mut linker2, |cx: &mut Context2| &mut cx.wasi)?;
     exec::add_to_linker(&mut linker)?;
+
+    // put dummy implementation to these import functions
+    let ty = GlobalType::new(ValType::I32, Mutability::Const);
+    let g = Global::new(&mut store, ty, Val::I32(0x1234))?;
+    linker2.define("exec", "events::get", g)?;
+    linker2.define("exec", "events::exec", g)?;
+    linker2.define("canonical_abi", "resource_drop_events", g)?;
 
     let module = "./target/wasm32-wasi/release/demo.wasm";
     let module = Module::from_file(&engine, module)?;
     let instance = linker.instantiate(&mut store, &module)?;
+    let instance2 = linker2.instantiate(&mut store2, &module)?;
 
-    let handler = EventHandler::new(&mut store, &instance, |cx: &mut Context| &mut cx.guest)?;
+    let handler = EventHandler::new(&mut store2, &instance2, |cx: &mut Context2| &mut cx.guest)?;
     store.data_mut().host = (
         Some(Arc::new(Mutex::new(handler))),
         Some(Arc::new(Mutex::new(ExecTables::default()))),
+        Some(Arc::new(Mutex::new(store2))),
     );
     instance
         .get_typed_func::<(), (), _>(&mut store, "_start")?


### PR DESCRIPTION
It turns out that the exec() function needs another engine to execute. 