### PR TITLE
Restructured host.rs to match generated bindings

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -1,11 +1,20 @@
 pub mod exec {
-    use std::{ops::DerefMut, thread};
-
-    use wasmtime::{AsContext, AsContextMut};
+    use wasmtime::Trap;
     #[allow(unused_imports)]
     use wit_bindgen_wasmtime::{anyhow, wasmtime};
+    pub trait Exec: Sized {
+        type Context: Ctx;
+        fn events_get(caller: wasmtime::Caller<'_, Self::Context>) -> Result<i32, Trap>;
 
-    use crate::Context;
+        fn events_exec(caller: wasmtime::Caller<'_, Self::Context>, _arg0: i32)
+            -> Result<(), Trap>;
+
+        fn drop_events(
+            caller: wasmtime::Caller<'_, Self::Context>,
+            handle: u32,
+        ) -> Result<(), Trap>;
+    }
+    use crate::Ctx;
 
     pub struct ExecTables {
         pub(crate) events_table: wit_bindgen_wasmtime::Table<()>,
@@ -17,56 +26,26 @@ pub mod exec {
             }
         }
     }
-    pub fn add_to_linker(linker: &mut wasmtime::Linker<Context>) -> anyhow::Result<()> {
+    pub fn add_to_linker<T: Ctx + Exec>(
+        linker: &mut wasmtime::Linker<T::Context>,
+    ) -> anyhow::Result<()> {
         linker.func_wrap(
             "exec",
             "events::get",
-            move |caller: wasmtime::Caller<'_, Context>| {
-                let store = caller.as_context();
-                let _tables = store.data().host.1.as_ref().unwrap();
-                let handle = _tables.clone().lock().unwrap().events_table.insert(());
-                Ok(handle as i32)
-            },
+            move |caller: wasmtime::Caller<'_, T::Context>| T::events_get(caller),
         )?;
         linker.func_wrap(
             "exec",
             "events::exec",
-            move |mut caller: wasmtime::Caller<'_, Context>, _arg0: i32| {
-                let mut thread_handles = vec![];
-                for i in 0..10 {
-                    let store = caller.as_context();
-                    let handler = store.data().host.0.as_ref().unwrap().clone();
-                    let mut store = caller.as_context_mut();
-                    let store = store.data_mut().host.2.as_mut().unwrap().clone();
-                    thread_handles.push(thread::spawn(move || {
-                        let mut store = store.lock().unwrap();
-                        let _res = handler
-                            .lock()
-                            .unwrap()
-                            .event_handler(store.deref_mut(), format!("event-{i}").as_str());
-                    }));
-                }
-                for handle in thread_handles {
-                    handle.join().unwrap();
-                }
-                Ok(())
+            move |mut caller: wasmtime::Caller<'_, T::Context>, _arg0: i32| {
+                T::events_exec(caller, _arg0)
             },
         )?;
         linker.func_wrap(
             "canonical_abi",
             "resource_drop_events",
-            move |caller: wasmtime::Caller<'_, Context>, handle: u32| {
-                let store = caller.as_context();
-                let _tables = store.data().host.1.as_ref().unwrap();
-                _tables
-                    .clone()
-                    .lock()
-                    .unwrap()
-                    .events_table
-                    .remove(handle)
-                    .map_err(|e| wasmtime::Trap::new(format!("failed to remove handle: {}", e)))?;
-                drop(handle);
-                Ok(())
+            move |caller: wasmtime::Caller<'_, T::Context>, handle: u32| {
+                T::drop_events(caller, handle)
             },
         )?;
         Ok(())

--- a/src/host.rs
+++ b/src/host.rs
@@ -37,7 +37,7 @@ pub mod exec {
         linker.func_wrap(
             "exec",
             "events::exec",
-            move |mut caller: wasmtime::Caller<'_, T::Context>, _arg0: i32| {
+            move |caller: wasmtime::Caller<'_, T::Context>, _arg0: i32| {
                 T::events_exec(caller, _arg0)
             },
         )?;


### PR DESCRIPTION
Created a new trait called Exec, which contains an associated type named Context that is used to define `add_to_linker` in host.rs. Both the host and guest contexts implement this trait. 